### PR TITLE
IMPT-0003 Fix: color swatch text overflow fix / added `text-overflow` utility

### DIFF
--- a/packages/css-definitions/src/index.ts
+++ b/packages/css-definitions/src/index.ts
@@ -94,6 +94,7 @@ import "./styles/typography/pre";
 import "./styles/typography/tables";
 // require("./typography/main");
 import "./utilities/imprint-article";
+import "./utilities/text-overflow";
 
 // ----------------------------------------------------------------
 //

--- a/packages/css-definitions/src/utilities/text-overflow.ts
+++ b/packages/css-definitions/src/utilities/text-overflow.ts
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2025-present Ganbaro Digital Ltd
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//   * Re-distributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//
+//   * Neither the names of the copyright holders nor the names of his
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+import { newStaticStyle } from "@imprintcss/tailwind-plugin-types";
+import { DEFINITION_STORE } from "../definitionStore/DEFINITION_STORE";
+
+const staticStyle = newStaticStyle(
+    "text-overflow",
+    {
+        utilityStyles: {
+            ".text-overflow-normal": {
+                "overflow-wrap": "normal",
+            },
+            ".text-overflow-anywhere": {
+                "overflow-wrap": "anywhere",
+            },
+            ".text-overflow-breakword": {
+                "overflow-wrap": "break-word",
+            }
+        }
+    }
+);
+
+DEFINITION_STORE.addStaticStyle(staticStyle);

--- a/packages/docs/src/components/Colors/ColorBlock.astro
+++ b/packages/docs/src/components/Colors/ColorBlock.astro
@@ -26,7 +26,7 @@ const displayName = shortName || color.name;
     <button class="w-full px-4 py-4" style={swatchStyle}>
         <div class="flex justify-between grow-1">
             <span class="block text-left">
-                <a href="" title="copy to clipboard" class="relative font-bold" data-clipboard={color.name}>{displayName}</a>
+                <a href="" title="copy to clipboard" class="relative font-bold text-overflow-anywhere" data-clipboard={color.name}>{displayName}</a>
             </span>
             <span class="block font-bold">
                 <a href="" title="copy to clipboard" class="relative" data-clipboard={color.hex.toUpperCase()}>{color.hex.toUpperCase()}

--- a/packages/docs/src/components/Colors/ColorSwatch.astro
+++ b/packages/docs/src/components/Colors/ColorSwatch.astro
@@ -21,26 +21,29 @@ const displayName = shortName || color.name;
 
 ---
 
-<div class="bg-white border rounded border-imprint-lightgray">
-    <div class="m-2 overflow-hidden rounded --standout-md">
+<div class="grid row-span-3 gap-0 px-2 py-2 bg-white border rounded border-imprint-lightgray grid-rows-subgrid">
+    <div class="overflow-hidden rounded --standout-md">
         <a href={"/colors/" + colorName}>
             <div class="w-full aspect-[5/4]" style={swatchStyle}>
                 <p>&nbsp;</p>
             </div>
         </a>
     </div>
-    <div class="px-2 pb-2">
-        <span class="block">
+    <div>
+        <span class="block pt-2">
             <a href="" title="copy to clipboard" class="relative font-bold text-overflow-anywhere" data-clipboard={color.name}>{displayName}</a>
         </span>
         { shortName && <span class="block imprint-fontsize-minion">
-                <a href="" title="copy to clipboard" class="relative" data-clipboard={color.hex.toUpperCase()}>{color.hex.toUpperCase()}
-            </span>
-            <span class="block pt-2 imprint-fontsize-minion">
+            <a href="" title="copy to clipboard" class="relative" data-clipboard={color.hex.toUpperCase()}>{color.hex.toUpperCase()}
+        </span>
+        }
+    </div>
+    <div class="pb-1">
+        { shortName && <span class="block pt-2 imprint-fontsize-minion">
                 <a href={"/colors/" + color.name}>Info</a>
             </span>
         }
-        { !shortName && <div class="flex justify-between pt-1 pb-2 grow basis-1/2">
+        { !shortName && <div class="flex justify-between pt-1 grow basis-1/2">
                 <span class="block imprint-fontsize-minion">
                     <a href="" title="copy to clipboard" class="relative" data-clipboard={color.hex.toUpperCase()}>{color.hex.toUpperCase()}
                 </span>

--- a/packages/docs/src/components/Colors/ColorSwatch.astro
+++ b/packages/docs/src/components/Colors/ColorSwatch.astro
@@ -31,7 +31,7 @@ const displayName = shortName || color.name;
     </div>
     <div class="px-2 pb-2">
         <span class="block">
-            <a href="" title="copy to clipboard" class="relative font-bold" data-clipboard={color.name}>{displayName}</a>
+            <a href="" title="copy to clipboard" class="relative font-bold text-overflow-anywhere" data-clipboard={color.name}>{displayName}</a>
         </span>
         { shortName && <span class="block imprint-fontsize-minion">
                 <a href="" title="copy to clipboard" class="relative" data-clipboard={color.hex.toUpperCase()}>{color.hex.toUpperCase()}

--- a/packages/docs/src/components/Colors/FixedHeightColorSwatch.astro
+++ b/packages/docs/src/components/Colors/FixedHeightColorSwatch.astro
@@ -26,7 +26,7 @@ const swatchStyle = "background-color: " + color.hex + " !important; color: " + 
             </div>
         </a>
     </div>
-    <div class="px-2 pb-4 grid-rows-subgrid">
+    <div class="px-2 pb-3 grid-rows-subgrid">
         <span class="block">
             <a href="" title="copy to clipboard" class="relative font-bold text-overflow-anywhere" data-clipboard={color.name}>{color.name}</a>
         </span>

--- a/packages/docs/src/components/Colors/FixedHeightColorSwatch.astro
+++ b/packages/docs/src/components/Colors/FixedHeightColorSwatch.astro
@@ -20,13 +20,13 @@ const swatchStyle = "background-color: " + color.hex + " !important; color: " + 
 
 <div class="overflow-hidden bg-white border rounded border-imprint-lightgray">
     <div class="m-2 overflow-hidden rounded --standout-md">
-    <a href={"/colors/" + colorName}>
-    <div class="w-full h-100rpx" style={swatchStyle}>
-        <p>&nbsp;</p>
+        <a href={"/colors/" + colorName}>
+            <div class="w-full h-100rpx" style={swatchStyle}>
+                <p>&nbsp;</p>
+            </div>
+        </a>
     </div>
-    </a>
-    </div>
-    <div class="px-2 pb-4">
+    <div class="px-2 pb-4 grid-rows-subgrid">
         <span class="block">
             <a href="" title="copy to clipboard" class="relative font-bold text-overflow-anywhere" data-clipboard={color.name}>{color.name}</a>
         </span>

--- a/packages/docs/src/components/Colors/FixedHeightColorSwatch.astro
+++ b/packages/docs/src/components/Colors/FixedHeightColorSwatch.astro
@@ -28,7 +28,7 @@ const swatchStyle = "background-color: " + color.hex + " !important; color: " + 
     </div>
     <div class="px-2 pb-4">
         <span class="block">
-            <a href="" title="copy to clipboard" class="relative font-bold" data-clipboard={color.name}>{color.name}</a>
+            <a href="" title="copy to clipboard" class="relative font-bold text-overflow-anywhere" data-clipboard={color.name}>{color.name}</a>
         </span>
         <div class="flex justify-between grow basis-1/2">
             <span class="block imprint-fontsize-minion">


### PR DESCRIPTION
### What Does This PR Do?

This PR fixes two (related) visual bugs in the color swatch components in the docs:

1. very long color names no longer overflow out of the swatch
2. the CSS definition and `Info` link are now vertically aligned across swatches using CSS subgrid

As part of this fix, I've added a new `text-overflow-*` utility to Imprint CSS. I'll document this later on, when I get back to sorting out the documentation for the typography.